### PR TITLE
Fix Copyright Headers

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -18,10 +18,13 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2012, 2016, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #ifndef	_SYS_ARC_H

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -18,16 +18,19 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
- * Copyright 2013 Saso Kiselkov. All rights reserved.
- * Copyright (c) 2014 Integros [integros.com]
- * Copyright 2017 Joyent, Inc.
- * Copyright (c) 2017 Datto Inc.
- * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2011, 2019, Delphix. All rights reserved.
+ * Copyright (c) 2011, Nexenta Systems Inc. All rights reserved.
+ * Copyright (c) 2014, Spectra Logic Corporation. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2014, Integros. All rights reserved.
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017, Datto Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #ifndef _SYS_SPA_H

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -21,11 +21,13 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2011, Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2012, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright 2016 Toomas Soome <tsoome@me.com>
+ * Copyright (c) 2016, Toomas Soome. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #ifndef _ZIO_H

--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -20,9 +20,10 @@
  */
 
 /*
- * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2009, Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2015, 2016, Delphix. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
  * Use is subject to license terms.
- * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_ZIO_COMPRESS_H

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -1,7 +1,4 @@
 '\" te
-.\" Copyright (c) 2012, 2018 by Delphix. All rights reserved.
-.\" Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
-.\" Copyright (c) 2014, Joyent, Inc. All rights reserved.
 .\" The contents of this file are subject to the terms of the Common Development
 .\" and Distribution License (the "License").  You may not use this file except
 .\" in compliance with the License. You can obtain a copy of the license at
@@ -14,6 +11,10 @@
 .\" CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your
 .\" own identifying information:
 .\" Portions Copyright [yyyy] [name of copyright owner]
+.\" Copyright (c) 2012, 2018, Delphix. All rights reserved.
+.\" Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+.\" Copyright (c) 2014, Joyent Inc. All rights reserved.
+.\" Copyright (c) 2019, Klara Inc. All rights reserved.
 .TH ZPOOL-FEATURES 5 "Jun 8, 2018"
 .SH NAME
 zpool\-features \- ZFS pool feature descriptions

--- a/man/man8/zfsprops.8
+++ b/man/man8/zfsprops.8
@@ -19,16 +19,17 @@
 .\" CDDL HEADER END
 .\"
 .\"
-.\" Copyright (c) 2009 Sun Microsystems, Inc. All Rights Reserved.
-.\" Copyright 2011 Joshua M. Clulow <josh@sysmgr.org>
-.\" Copyright (c) 2011, 2019 by Delphix. All rights reserved.
-.\" Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
-.\" Copyright (c) 2014, Joyent, Inc. All rights reserved.
-.\" Copyright (c) 2014 by Adam Stevko. All rights reserved.
-.\" Copyright (c) 2014 Integros [integros.com]
-.\" Copyright 2019 Richard Laager. All rights reserved.
-.\" Copyright 2018 Nexenta Systems, Inc.
-.\" Copyright 2019 Joyent, Inc.
+.\" Copyright (c) 2009, Sun Microsystems, Inc. All Rights Reserved.
+.\" Copyright (c) 2011, Joshua M. Clulow. All Rights Reserved.
+.\" Copyright (c) 2011, 2019, Delphix. All rights reserved.
+.\" Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+.\" Copyright (c) 2014, Joyent Inc. All rights reserved.
+.\" Copyright (c) 2014, Adam Stevko. All rights reserved.
+.\" Copyright (c) 2014, Integros. All rights reserved.
+.\" Copyright (c) 2019, Richard Laager. All rights reserved.
+.\" Copyright (c) 2018, Nexenta Systems, Inc. All rights reserved.
+.\" Copyright (c) 2019, Joyent Inc. All rights reserved.
+.\" Copyright (c) 2019, Kjeld Schouten-Lebbing. All rights reserved.
 .\"
 .Dd June 30, 2019
 .Dt ZFSPROPS 8

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -24,7 +24,9 @@
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014, Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2017, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #ifndef _KERNEL

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -18,15 +18,16 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright 2016, Joyent, Inc.
- * Portions Copyright (c) 2019 by Klara Inc.
+ * Copyright (c) 2010, Robert Milkowski. All rights reserved.
+ * Copyright (c) 2011, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
-
-/* Portions Copyright 2010 Robert Milkowski */
 
 #include <sys/zio.h>
 #include <sys/spa.h>

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -18,14 +18,15 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, Joyent, Inc.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
- * Copyright (c) 2014 by Saso Kiselkov. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018, Joyent Inc. All rights reserved.
+ * Copyright (c) 2011, 2019, Delphix. All rights reserved.
+ * Copyright (c) 2014, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2017, Nexenta Systems Inc. All rights reserved.
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
- * Portions Copyright (c) 2019 by Klara Inc.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
  */
 
 /*

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -18,12 +18,15 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2012, 2019 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
+ * Copyright (c) 2011, Nexenta Systems Inc. All rights reserved.
+ * Copyright (c) 2012, 2019, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2014, Spectra Logic Corporation. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #include <sys/zfs_context.h>

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -18,14 +18,17 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2011, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2016, Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2015 by Chunwei Chen. All rights reserved.
- * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2015, Chunwei Chen. All rights reserved.
+ * Copyright (c) 2019, Datto Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #include <sys/dmu.h>

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -21,18 +21,19 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
- * Copyright (c) 2015, STRATO AG, Inc. All rights reserved.
- * Copyright (c) 2016 Actifio, Inc. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.
- * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
+ * Copyright (c) 2010, Robert Milkowski. All rights reserved.
+ * Copyright (c) 2012, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2013, Joyent Inc. All rights reserved.
+ * Copyright (c) 2014, Spectra Logic Corporation. All rights reserved.
+ * Copyright (c) 2015, STRATO AG. All rights reserved.
+ * Copyright (c) 2016, Actifio Inc. All rights reserved.
+ * Copyright (c) 2017, Nexenta Systems Inc. All Rights Reserved.
+ * Copyright (c) 2017, Open-E Inc. All Rights Reserved.
  * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
-
-/* Portions Copyright 2010 Robert Milkowski */
 
 #include <sys/zfeature.h>
 #include <sys/cred.h>

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -18,13 +18,16 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
- * Copyright 2014 HybridCluster. All rights reserved.
- * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+ * Copyright (c) 2011, Nexenta Systems Inc. All rights reserved.
+ * Copyright (c) 2011, 2018 Delphix. All rights reserved.
+ * Copyright (c) 2014, Joyent Inc. All rights reserved.
+ * Copyright (c) 2014, HybridCluster. All rights reserved.
+ * Copyright (c) 2018, loli10K. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #include <sys/dmu.h>

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -18,14 +18,17 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
- * Copyright 2014 HybridCluster. All rights reserved.
- * Copyright 2016 RackTop Systems.
- * Copyright (c) 2016 Actifio, Inc. All rights reserved.
+ * Copyright (c) 2011, Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2011, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2014, Joyent Inc. All rights reserved.
+ * Copyright (c) 2014, HybridCluster. All rights reserved.
+ * Copyright (c) 2016, RackTop Systems. All rights reserved.
+ * Copyright (c) 2016, Actifio Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #include <sys/dmu.h>

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -21,13 +21,15 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
- * Copyright (c) 2014 RackTop Systems.
- * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
- * Copyright (c) 2016 Actifio, Inc. All rights reserved.
- * Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.
+ * Copyright (c) 2011, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2014, Joyent Inc. All rights reserved.
+ * Copyright (c) 2014, RackTop Systems. All rights reserved.
+ * Copyright (c) 2014, Spectra Logic Corporation. All rights reserved.
+ * Copyright (c) 2016, Actifio Inc. All rights reserved.
+ * Copyright (c) 2016, OmniTI Computer Consulting Inc. All rights reserved.
+ * Copyright (c) 2017, Nexenta Systems Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #include <sys/dmu_objset.h>

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -14,8 +14,10 @@
  */
 
 /*
- * Copyright (c) 2016 by Delphix. All rights reserved.
- */
+ * Copyright (c) 2016, Delphix. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
+*/
 
 #include <sys/lua/lua.h>
 #include <sys/lua/lualib.h>

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -21,22 +21,23 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright 2011 Martin Matuska
- * Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
- * Portions Copyright 2012 Pawel Jakub Dawidek <pawel@dawidek.net>
- * Copyright (c) 2014, 2016 Joyent, Inc. All rights reserved.
- * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2014, Joyent, Inc. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright (c) 2013 Steven Hartland. All rights reserved.
- * Copyright (c) 2014 Integros [integros.com]
- * Copyright 2016 Toomas Soome <tsoome@me.com>
- * Copyright (c) 2016 Actifio, Inc. All rights reserved.
+ * Copyright (c) 2011, Martin Matuska. All rights reserved.
+ * Copyright (c) 2015, OmniTI Computer Consulting Inc. All rights reserved.
+ * Copyright (c) 2012, Pawel Jakub Dawidek. All rights reserved.
+ * Copyright (c) 2014, 2016, Joyent Inc. All rights reserved.
+ * Copyright (c) 2016, Nexenta Systems Inc. All rights reserved.
+ * Copyright (c) 2011, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2013, Steven Hartland. All rights reserved.
+ * Copyright (c) 2014, Integros. All rights reserved.
+ * Copyright (c) 2016, Toomas Soome. All rights reserved.
+ * Copyright (c) 2016, Actifio Inc. All rights reserved.
  * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
- * Copyright 2017 RackTop Systems.
- * Copyright (c) 2017 Open-E, Inc. All Rights Reserved.
- * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2017, RackTop Systems. All rights reserved.
+ * Copyright (c) 2017, Open-E Inc. All Rights Reserved.
+ * Copyright (c) 2019, Datto Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 /*

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -18,11 +18,14 @@
  *
  * CDDL HEADER END
  */
+ 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
- * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2011, 2019, Delphix. All rights reserved.
+ * Copyright (c) 2011, Nexenta Systems Inc. All rights reserved.
+ * Copyright (c) 2017, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Use is subject to license terms.
  */
 
 #include <sys/sysmacros.h>

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -20,15 +20,11 @@
  */
 
 /*
- * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2009, Sun Microsystems Inc. All rights reserved.
+ * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
+ * Copyright (c) 2013, 2018, Delphix. All rights reserved.
+ * Copyright (c) 2019, Klara Inc. All rights reserved.
  * Use is subject to license terms.
- */
-/*
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- */
-
-/*
- * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>

--- a/module/zstd/zstd.c
+++ b/module/zstd/zstd.c
@@ -26,9 +26,9 @@
  */
 
 /*
- * Copyright (c) 2016-2018 by Klara Systems Inc.
- * Copyright (c) 2016-2018 Allan Jude <allanjude@freebsd.org>
- * Copyright (c) 2018-2019 Sebastian Gottschall <s.gottschall@dd-wrt.com>
+ * Copyright (c) 2016-2018, Klara Systems Inc. All rights reserved.
+ * Copyright (c) 2016-2018, Allan Jude. All rights reserved.
+ * Copyright (c) 2018-2019, Sebastian Gottschall. All rights reserved.
  */
 
 #include <sys/param.h>


### PR DESCRIPTION
- Adds copyright headers for Allan Jude / Klara Inc.
- Added Ornias1993 Copyright
- Cleans copyright header formatting
- Removes email adresses (not part of the usual format, gets outdated etc)*

*exception is lolli10K who shouldn't have used a nickname in the firstplace. A nickname is NOT the legal copyright holder. Kept email for identification purposes.