### PR TITLE
Fix for codecov mistake

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -22,4 +22,4 @@ comment:
   require_changes: yes		# only post when coverage changes
 
 ignore:
-  - "contrib/zstd"		# Dependencies don't need coverage testing
+  - "contrib/zstd/**/*"		# Dependencies don't need coverage testing


### PR DESCRIPTION
Here I made the same stupid mistake as zfsonlinux/zfs/#9672
Google points to codecov 1.0 docs, 
whereas 4.4.0 docs show a about how to do recursive bahavior correctly.