### PR TITLE
zdb extensions for zstd

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -27,7 +27,7 @@
  * Copyright (c) 2017, 2018 Lawrence Livermore National Security, LLC.
  * Copyright (c) 2015, 2017, Intel Corporation.
  * Copyright (c) 2020 Datto Inc.
- * Copyright (c) 2020 The FreeBSD Foundation
+ * Copyright (c) 2020 The FreeBSD Foundation.
  *
  * Portions of this software were developed by Allan Jude
  * under sponsorship from the FreeBSD Foundation.

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1586,6 +1586,7 @@ snprintf_zstd_header(spa_t *spa, char *blkbuf, size_t buflen,
 		}
 		decode_embedded_bp_compressed(bp, buf);
 		memcpy(&zstd_hdr, buf, sizeof (zstd_hdr));
+		free(buf);
 		zstd_hdr.c_len = BE_32(zstd_hdr.c_len);
 		zstd_hdr.raw_version_level = BE_32(zstd_hdr.raw_version_level);
 		(void) snprintf(blkbuf + strlen(blkbuf),

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -27,9 +27,9 @@
  * Copyright (c) 2017, 2018 Lawrence Livermore National Security, LLC.
  * Copyright (c) 2015, 2017, Intel Corporation.
  * Copyright (c) 2020 Datto Inc.
- * Copyright (c) 2020 The FreeBSD Foundation.
+ * Copyright (c) 2020 The FreeBSD Foundation. [1]
  *
- * Portions of this software were developed by Allan Jude
+ * [1] Portions of this software were developed by Allan Jude
  * under sponsorship from the FreeBSD Foundation.
  */
 

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -27,6 +27,10 @@
  * Copyright (c) 2017, 2018 Lawrence Livermore National Security, LLC.
  * Copyright (c) 2015, 2017, Intel Corporation.
  * Copyright (c) 2020 Datto Inc.
+ * Copyright (c) 2020 The FreeBSD Foundation
+ *
+ * Portions of this software were developed by Allan Jude
+ * under sponsorship from the FreeBSD Foundation.
  */
 
 #include <stdio.h>
@@ -70,6 +74,7 @@
 #include <sys/dsl_crypt.h>
 #include <sys/dsl_scan.h>
 #include <zfs_comutil.h>
+#include <sys/zstd/zstd.h>
 
 #include <libnvpair.h>
 #include <libzutil.h>
@@ -1558,6 +1563,64 @@ blkid2offset(const dnode_phys_t *dnp, const blkptr_t *bp,
 }
 
 static void
+snprintf_zstd_header(spa_t *spa, char *blkbuf, size_t buflen,
+    const blkptr_t *bp)
+{
+	abd_t *pabd;
+	void *buf;
+	zio_t *zio;
+	zfs_zstdhdr_t zstd_hdr;
+	int error;
+
+	if (BP_GET_COMPRESS(bp) != ZIO_COMPRESS_ZSTD)
+		return;
+
+	if (BP_IS_HOLE(bp))
+		return;
+
+	if (BP_IS_EMBEDDED(bp)) {
+		buf = malloc(SPA_MAXBLOCKSIZE);
+		if (buf == NULL) {
+			(void) fprintf(stderr, "out of memory\n");
+			exit(1);
+		}
+		decode_embedded_bp_compressed(bp, buf);
+		memcpy(&zstd_hdr, buf, sizeof (zstd_hdr));
+		zstd_hdr.c_len = BE_32(zstd_hdr.c_len);
+		zstd_hdr.raw_version_level = BE_32(zstd_hdr.raw_version_level);
+		(void) snprintf(blkbuf + strlen(blkbuf),
+		    buflen - strlen(blkbuf),
+		    " ZSTD:size=%u:version=%u:level=%u:EMBEDDED",
+		    zstd_hdr.c_len, zstd_hdr.version, zstd_hdr.level);
+		return;
+	}
+
+	pabd = abd_alloc_for_io(SPA_MAXBLOCKSIZE, B_FALSE);
+	zio = zio_root(spa, NULL, NULL, 0);
+
+	/* Decrypt but don't decompress so we can read the compression header */
+	zio_nowait(zio_read(zio, spa, bp, pabd, BP_GET_PSIZE(bp), NULL, NULL,
+	    ZIO_PRIORITY_SYNC_READ, ZIO_FLAG_CANFAIL | ZIO_FLAG_RAW_COMPRESS,
+	    NULL));
+	error = zio_wait(zio);
+	if (error) {
+		(void) fprintf(stderr, "read failed: %d\n", error);
+		return;
+	}
+	buf = abd_borrow_buf_copy(pabd, BP_GET_LSIZE(bp));
+	memcpy(&zstd_hdr, buf, sizeof (zstd_hdr));
+	zstd_hdr.c_len = BE_32(zstd_hdr.c_len);
+	zstd_hdr.raw_version_level = BE_32(zstd_hdr.raw_version_level);
+
+	(void) snprintf(blkbuf + strlen(blkbuf),
+	    buflen - strlen(blkbuf),
+	    " ZSTD:size=%u:version=%u:level=%u:NORMAL",
+	    zstd_hdr.c_len, zstd_hdr.version, zstd_hdr.level);
+
+	abd_return_buf_copy(pabd, buf, BP_GET_LSIZE(bp));
+}
+
+static void
 snprintf_blkptr_compact(char *blkbuf, size_t buflen, const blkptr_t *bp,
     boolean_t bp_freed)
 {
@@ -1621,7 +1684,7 @@ snprintf_blkptr_compact(char *blkbuf, size_t buflen, const blkptr_t *bp,
 }
 
 static void
-print_indirect(blkptr_t *bp, const zbookmark_phys_t *zb,
+print_indirect(spa_t *spa, blkptr_t *bp, const zbookmark_phys_t *zb,
     const dnode_phys_t *dnp)
 {
 	char blkbuf[BP_SPRINTF_LEN];
@@ -1645,6 +1708,8 @@ print_indirect(blkptr_t *bp, const zbookmark_phys_t *zb,
 	}
 
 	snprintf_blkptr_compact(blkbuf, sizeof (blkbuf), bp, B_FALSE);
+	if (dump_opt['Z'] && BP_GET_COMPRESS(bp) == ZIO_COMPRESS_ZSTD)
+		snprintf_zstd_header(spa, blkbuf, sizeof (blkbuf), bp);
 	(void) printf("%s\n", blkbuf);
 }
 
@@ -1657,7 +1722,7 @@ visit_indirect(spa_t *spa, const dnode_phys_t *dnp,
 	if (bp->blk_birth == 0)
 		return (0);
 
-	print_indirect(bp, zb, dnp);
+	print_indirect(spa, bp, zb, dnp);
 
 	if (BP_GET_LEVEL(bp) > 0 && !BP_IS_HOLE(bp)) {
 		arc_flags_t flags = ARC_FLAG_WAIT;
@@ -7334,7 +7399,7 @@ main(int argc, char **argv)
 	zfs_btree_verify_intensity = 3;
 
 	while ((c = getopt(argc, argv,
-	    "AbcCdDeEFGhiI:klLmMo:Op:PqRsSt:uU:vVx:XY")) != -1) {
+	    "AbcCdDeEFGhiI:klLmMo:Op:PqRsSt:uU:vVx:XYZ")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
@@ -7353,6 +7418,7 @@ main(int argc, char **argv)
 		case 's':
 		case 'S':
 		case 'u':
+		case 'Z':
 			dump_opt[c]++;
 			dump_all = 0;
 			break;

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -23,8 +23,8 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2016, Delphix. All rights reserved.
  * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Copyright (c) 2019, Allan Jude.
+ * Copyright (c) 2019, Klara Inc.
  * Use is subject to license terms.
  */
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -29,8 +29,8 @@
  * Copyright (c) 2017, Joyent, Inc. All rights reserved.
  * Copyright (c) 2017, Datto Inc. All rights reserved.
  * Copyright (c) 2017, Intel Corporation. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Copyright (c) 2019, Allan Jude.
+ * Copyright (c) 2019, Klara Inc.
  * Use is subject to license terms.
  */
 

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -26,8 +26,8 @@
  * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2016, Toomas Soome. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Copyright (c) 2019, Allan Jude.
+ * Copyright (c) 2019, Klara Inc.
  * Use is subject to license terms.
  */
 

--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -22,8 +22,8 @@
 /*
  * Copyright (c) 2009, Sun Microsystems Inc. All rights reserved.
  * Copyright (c) 2015, 2016, Delphix. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Copyright (c) 2019, Allan Jude.
+ * Copyright (c) 2019, Klara Inc.
  * Use is subject to license terms.
  */
 

--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -25,6 +25,10 @@
  * Copyright (c) 2016-2018, Allan Jude.
  * Copyright (c) 2018-2019, Sebastian Gottschall. All rights reserved.
  * Copyright (c) 2019-2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2020 The FreeBSD Foundation.
+ *
+ * Portions of this software were developed by Allan Jude
+ * under sponsorship from the FreeBSD Foundation.
  */
 
 #ifndef	_ZFS_ZSTD_H
@@ -58,6 +62,14 @@ typedef struct zfs_zstd_header {
 
 	char data[];
 } zfs_zstdhdr_t;
+
+/*
+ * kstat helper macros
+ */
+#define	ZSTDSTAT(stat)		(zstd_stats.stat.value.ui64)
+#define	ZSTDSTAT_INCR(stat, val) \
+	atomic_add_64(&zstd_stats.stat.value.ui64, (val))
+#define	ZSTDSTAT_BUMP(stat)	ZSTDSTAT_INCR(stat, 1)
 
 /* (de)init for user space / kernel emulation */
 int zstd_init(void);

--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -34,6 +34,30 @@
 extern "C" {
 #endif
 
+/*
+ * ZSTD block header
+ * NOTE: all fields in this header are in big endian order.
+ */
+typedef struct zfs_zstd_header {
+	/* Compressed size of data */
+	uint32_t c_len;
+
+	/*
+	 * Version and compression level
+	 * We have to choose a union here to handle endian conversation
+	 * correctly, since the version and level is bitmask encoded.
+	 */
+	union {
+		uint32_t raw_version_level;
+		struct {
+			uint32_t version : 24;
+			uint8_t level;
+		};
+	};
+
+	char data[];
+} zfs_zstdhdr_t;
+
 /* (de)init for user space / kernel emulation */
 int zstd_init(void);
 void zstd_fini(void);

--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -21,8 +21,8 @@
  */
 
 /*
- * Copyright (c) 2016-2018, Klara Systems Inc. All rights reserved.
- * Copyright (c) 2016-2018, Allan Jude. All rights reserved.
+ * Copyright (c) 2016-2018, Klara Inc.
+ * Copyright (c) 2016-2018, Allan Jude.
  * Copyright (c) 2018-2019, Sebastian Gottschall. All rights reserved.
  * Copyright (c) 2019-2020, Michael Niewöhner. All rights reserved.
  */

--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -44,8 +44,9 @@ typedef struct zfs_zstd_header {
 
 	/*
 	 * Version and compression level
-	 * We have to choose a union here to handle endian conversation
-	 * correctly, since the version and level is bitmask encoded.
+	 * We use a union to be able to big endian encode a single 32 bit
+	 * unsigned integer, but still access the individual bitmasked
+	 * components easily.
 	 */
 	union {
 		uint32_t raw_version_level;

--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -14,8 +14,8 @@
 .\" Copyright (c) 2012, 2018, Delphix. All rights reserved.
 .\" Copyright (c) 2013, Saso Kiselkov. All rights reserved.
 .\" Copyright (c) 2014, Joyent Inc. All rights reserved.
-.\" Copyright (c) 2019, Klara Inc. All rights reserved.
-.\" Copyright (c) 2019, Allan Jude. All rights reserved.
+.\" Copyright (c) 2019, Klara Inc.
+.\" Copyright (c) 2019, Allan Jude.
 .TH ZPOOL-FEATURES 5 "Jun 8, 2018"
 .SH NAME
 zpool\-features \- ZFS pool feature descriptions

--- a/module/zcommon/zfeature_common.c
+++ b/module/zcommon/zfeature_common.c
@@ -25,8 +25,8 @@
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
  * Copyright (c) 2014, Nexenta Systems Inc. All rights reserved.
  * Copyright (c) 2017, Intel Corporation. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -25,7 +25,7 @@
  * Copyright (c) 2011, 2018, Delphix. All rights reserved.
  * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2016, Joyent, Inc. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -26,7 +26,7 @@
  * Copyright (c) 2014, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2017, Nexenta Systems Inc. All rights reserved.
  * Copyright (c) 2019, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
  * Copyright (c) 2020, George Amanakis. All rights reserved.
  */
 

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -25,8 +25,8 @@
  * Copyright (c) 2012, 2019, Delphix. All rights reserved.
  * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014, Spectra Logic Corporation. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -27,8 +27,8 @@
  * Copyright (c) 2016, Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2015, Chunwei Chen. All rights reserved.
  * Copyright (c) 2019, Datto Inc. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -31,8 +31,8 @@
  * Copyright (c) 2017, Nexenta Systems Inc. All Rights Reserved.
  * Copyright (c) 2017, Open-E Inc. All Rights Reserved.
  * Copyright (c) 2018, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -26,8 +26,8 @@
  * Copyright (c) 2014, Joyent Inc. All rights reserved.
  * Copyright (c) 2014, HybridCluster. All rights reserved.
  * Copyright (c) 2018, loli10K. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -27,8 +27,8 @@
  * Copyright (c) 2014, HybridCluster. All rights reserved.
  * Copyright (c) 2016, RackTop Systems. All rights reserved.
  * Copyright (c) 2016, Actifio Inc. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -28,8 +28,8 @@
  * Copyright (c) 2016, Actifio Inc. All rights reserved.
  * Copyright (c) 2016, OmniTI Computer Consulting Inc. All rights reserved.
  * Copyright (c) 2017, Nexenta Systems Inc. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/zcp_get.c
+++ b/module/zfs/zcp_get.c
@@ -15,8 +15,8 @@
 
 /*
  * Copyright (c) 2016, Delphix. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -37,8 +37,8 @@
  * Copyright (c) 2017, Open-E Inc. All Rights Reserved.
  * Copyright (c) 2019, Datto Inc. All rights reserved.
  * Copyright (c) 2019, 2020, Christian Schwarz. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -24,8 +24,8 @@
  * Copyright (c) 2011, 2019, Delphix. All rights reserved.
  * Copyright (c) 2011, Nexenta Systems Inc. All rights reserved.
  * Copyright (c) 2017, Intel Corporation. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -23,8 +23,8 @@
  * Copyright (c) 2009, Sun Microsystems Inc. All rights reserved.
  * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, 2018, Delphix. All rights reserved.
- * Copyright (c) 2019, Klara Inc. All rights reserved.
- * Copyright (c) 2019, Allan Jude. All rights reserved.
+ * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019, Allan Jude.
  * Use is subject to license terms.
  */
 

--- a/module/zstd/zstd.c
+++ b/module/zstd/zstd.c
@@ -36,30 +36,6 @@
 #define	ZSTD_STATIC_LINKING_ONLY
 #include "zstdlib.h"
 
-/*
- * ZSTD block header
- * NOTE: all fields in this header are in big endian order.
- */
-struct zstd_header {
-	/* Compressed size of data */
-	uint32_t c_len;
-
-	/*
-	 * Version and compression level
-	 * We have to choose a union here to handle endian conversation
-	 * correctly, since the version and level is bitmask encoded.
-	 */
-	union {
-		uint32_t raw_version_level;
-		struct {
-			uint32_t version : 24;
-			uint8_t level;
-		};
-	};
-
-	char data[];
-};
-
 /* Enums describing the allocator type specified by kmem_type in zstd_kmem */
 enum zstd_kmem_type {
 	ZSTD_KMEM_UNKNOWN = 0,

--- a/module/zstd/zstd.c
+++ b/module/zstd/zstd.c
@@ -20,11 +20,11 @@
  */
 
 /*
- * Copyright (c) 2016-2018, Klara Systems Inc. All rights reserved.
- * Copyright (c) 2016-2018, Allan Jude. All rights reserved.
+ * Copyright (c) 2016-2018, Klara Inc.
+ * Copyright (c) 2016-2018, Allan Jude.
  * Copyright (c) 2018-2020, Sebastian Gottschall. All rights reserved.
  * Copyright (c) 2019-2020, Michael Niewöhner. All rights reserved.
- * Copyright (c) 2020 The FreeBSD Foundation
+ * Copyright (c) 2020 The FreeBSD Foundation.
  *
  * Portions of this software were developed by Allan Jude
  * under sponsorship from the FreeBSD Foundation.

--- a/module/zstd/zstd.c
+++ b/module/zstd/zstd.c
@@ -24,9 +24,9 @@
  * Copyright (c) 2016-2018, Allan Jude.
  * Copyright (c) 2018-2020, Sebastian Gottschall. All rights reserved.
  * Copyright (c) 2019-2020, Michael Niewöhner. All rights reserved.
- * Copyright (c) 2020 The FreeBSD Foundation.
+ * Copyright (c) 2020 The FreeBSD Foundation. [1]
  *
- * Portions of this software were developed by Allan Jude
+ * [1] Portions of this software were developed by Allan Jude
  * under sponsorship from the FreeBSD Foundation.
  */
 


### PR DESCRIPTION
Add an extension to zdb to be able to decode the zstd compression header

Moves the zstd_header definitions to the .h file so it can be reused in zdb

Also fixes up the comments around `zstd_enum_to_cookie()`
