### PR TITLE
Remove -Z from the list of invalid zdb parameters

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
@@ -58,7 +58,7 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "setvprop" "blah blah" "-%" "--?" "-*" "-=" \
     "-a" "-f" "-g" "-j" "-n" "-o" "-p" "-p /tmp" "-r" \
     "-t" "-w" "-y" "-z" "-E" "-H" "-I" "-J" "-K" \
-    "-N" "-Q" "-R" "-T" "-W" "-Z"
+    "-N" "-Q" "-R" "-T" "-W"
 
 log_assert "Execute zdb using invalid parameters."
 


### PR DESCRIPTION
This change removes "-Z" from the invalid ZDB parameters test...

Allan might want to change it later (to improve this), but this would ensure in a clean and simple way we pass tests again.