### PR TITLE
More copyright header cleanup

### DIFF
--- a/cmd/dbufstat/dbufstat
+++ b/cmd/dbufstat/dbufstat
@@ -23,9 +23,11 @@
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
 # CDDL HEADER END
+
 #
-# Copyright (C) 2013 Lawrence Livermore National Security, LLC.
+# Copyright (C) 2013, Lawrence Livermore National Security LLC.
 # Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
+
 #
 # This script must remain compatible with Python 2.6+ and Python 3.4+.
 #

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -19,11 +19,11 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, Delphix. All rights reserved.
- * Copyright (c) 2013, Saso Kiselkov. All rights reserved.
- * Copyright (c) 2013, Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2020, George Amanakis. All rights reserved.
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates
+ * Copyright (c) 2013, Delphix
+ * Copyright (c) 2013, Saso Kiselkov
+ * Copyright (c) 2013, Nexenta Systems, Inc.
+ * Copyright (c) 2020, George Amanakis
  */
 
 #ifndef _SYS_ARC_IMPL_H

--- a/include/sys/dmu_objset.h
+++ b/include/sys/dmu_objset.h
@@ -19,13 +19,13 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates
+ * Copyright (c) 2010, Robert Milkowski
+ * Copyright (c) 2012, 2018, Delphix
+ * Copyright (c) 2013, Saso Kiselkov.
+ * Copyright (c) 2014, Spectra Logic Inc.
  */
 
-/* Portions Copyright 2010 Robert Milkowski */
 
 #ifndef	_SYS_DMU_OBJSET_H
 #define	_SYS_DMU_OBJSET_H

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -20,16 +20,15 @@
  */
 
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2020 by Delphix. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2013, 2017 Joyent, Inc. All rights reserved.
- * Copyright (c) 2014 Integros [integros.com]
- * Copyright (c) 2017, Intel Corporation.
- * Copyright (c) 2019 Datto Inc.
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates
+ * Copyright (c) 2010, Robert Milkowski
+ * Copyright (c) 2011, 2020, Delphix
+ * Copyright (c) 2011, Nexenta Systems, Inc.
+ * Copyright (c) 2013, 2017 Joyent, Inc.
+ * Copyright (c) 2014, Integros
+ * Copyright (c) 2017, Intel Inc.
+ * Copyright (c) 2019, Datto Inc.
  */
-
-/* Portions Copyright 2010 Robert Milkowski */
 
 #ifndef	_SYS_FS_ZFS_H
 #define	_SYS_FS_ZFS_H

--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -19,10 +19,11 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates
+ * Copyright (c) 2011, Nexenta Systems Inc.
+ * Copyright (c) 2012, 2018, Delphix
+ * Copyright (c) 2012, Joyent Inc.
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef _SYS_ZFS_CONTEXT_H

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -19,10 +19,10 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2020 by Delphix. All rights reserved.
- * Copyright 2016 RackTop Systems.
- * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates
+ * Copyright (c) 2012, 2020, Delphix
+ * Copyright (c) 2016, RackTop Systems
+ * Copyright (c) 2017, Intel inc.
  */
 
 #ifndef	_SYS_ZFS_IOCTL_H

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -28,6 +28,7 @@
  * Copyright (c) 2016, Toomas Soome
  * Copyright (c) 2019, Allan Jude
  * Copyright (c) 2019, Klara Inc.
+ * Copyright (c) 2019-2020, Michael Niewöhner
  * Use is subject to license terms.
  */
 

--- a/include/sys/zstd/zstd.h
+++ b/include/sys/zstd/zstd.h
@@ -22,10 +22,10 @@
 
 /*
  * Copyright (c) 2016-2018, Klara Inc.
- * Copyright (c) 2016-2018, Allan Jude.
- * Copyright (c) 2018-2019, Sebastian Gottschall. All rights reserved.
- * Copyright (c) 2019-2020, Michael Niewöhner. All rights reserved.
- * Copyright (c) 2020, The FreeBSD Foundation. [1]
+ * Copyright (c) 2016-2018, Allan Jude
+ * Copyright (c) 2018-2019, Sebastian Gottschall
+ * Copyright (c) 2019-2020, Michael Niewöhner
+ * Copyright (c) 2020, The FreeBSD Foundation [1]
  *
  * [1] Portions of this software were developed by Allan Jude under
  *     sponsorship from the FreeBSD Foundation.

--- a/include/zfeature_common.h
+++ b/include/zfeature_common.h
@@ -20,10 +20,10 @@
  */
 
 /*
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright (c) 2017, Intel Corporation.
+ * Copyright (c) 2011, 2018, Delphix
+ * Copyright (c) 2013, Saso Kiselkov
+ * Copyright (c) 2013, Joyent Inc.
+ * Copyright (c) 2017, Intel Inc.
  */
 
 #ifndef _ZFEATURE_COMMON_H

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -19,9 +19,10 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
- * Copyright (c) 2016 Actifio, Inc. All rights reserved.
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates
+ * Copyright (c) 2012, 2018, Delphix
+ * Copyright (c) 2016, Actifio Inc.
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #include <assert.h>

--- a/module/zstd/include/aarch64_compat.h
+++ b/module/zstd/include/aarch64_compat.h
@@ -24,7 +24,7 @@
  */
 
 /*
- * Copyright (c) 2018-2020, Sebastian Gottschall. All rights reserved.
+ * Copyright (c) 2018-2020, Sebastian Gottschall
  */
 
 #ifdef _KERNEL

--- a/module/zstd/include/limits.h
+++ b/module/zstd/include/limits.h
@@ -24,9 +24,9 @@
  */
 
 /*
- * Copyright (c) 2014-2019, Allan Jude. All rights reserved.
- * Copyright (c) 2020, Brian Behlendorf. All rights reserved.
- * Copyright (c) 2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2014-2019, Allan Jude
+ * Copyright (c) 2020, Brian Behlendorf
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef	_ZSTD_LIMITS_H

--- a/module/zstd/include/stddef.h
+++ b/module/zstd/include/stddef.h
@@ -24,9 +24,9 @@
  */
 
 /*
- * Copyright (c) 2014-2019, Allan Jude. All rights reserved.
- * Copyright (c) 2020, Brian Behlendorf. All rights reserved.
- * Copyright (c) 2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2014-2019, Allan Jude
+ * Copyright (c) 2020, Brian Behlendorf
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef	_ZSTD_STDDEF_H

--- a/module/zstd/include/stdint.h
+++ b/module/zstd/include/stdint.h
@@ -24,9 +24,9 @@
  */
 
 /*
- * Copyright (c) 2014-2019, Allan Jude. All rights reserved.
- * Copyright (c) 2020, Brian Behlendorf. All rights reserved.
- * Copyright (c) 2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2014-2019, Allan Jude
+ * Copyright (c) 2020, Brian Behlendorf
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef	_ZSTD_STDINT_H

--- a/module/zstd/include/stdio.h
+++ b/module/zstd/include/stdio.h
@@ -24,9 +24,9 @@
  */
 
 /*
- * Copyright (c) 2014-2019, Allan Jude. All rights reserved.
- * Copyright (c) 2020, Brian Behlendorf. All rights reserved.
- * Copyright (c) 2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2014-2019, Allan Jude
+ * Copyright (c) 2020, Brian Behlendorf
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef	_ZSTD_STDIO_H

--- a/module/zstd/include/stdlib.h
+++ b/module/zstd/include/stdlib.h
@@ -24,9 +24,9 @@
  */
 
 /*
- * Copyright (c) 2014-2019, Allan Jude. All rights reserved.
- * Copyright (c) 2020, Brian Behlendorf. All rights reserved.
- * Copyright (c) 2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2014-2019, Allan Jude
+ * Copyright (c) 2020, Brian Behlendorf
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef	_ZSTD_STDLIB_H

--- a/module/zstd/include/string.h
+++ b/module/zstd/include/string.h
@@ -24,9 +24,9 @@
  */
 
 /*
- * Copyright (c) 2014-2019, Allan Jude. All rights reserved.
- * Copyright (c) 2020, Brian Behlendorf. All rights reserved.
- * Copyright (c) 2020, Michael Niewöhner. All rights reserved.
+ * Copyright (c) 2014-2019, Allan Jude
+ * Copyright (c) 2020, Brian Behlendorf
+ * Copyright (c) 2020, Michael Niewöhner
  */
 
 #ifndef	_ZSTD_STRING_H

--- a/module/zstd/zstd.c
+++ b/module/zstd/zstd.c
@@ -21,10 +21,10 @@
 
 /*
  * Copyright (c) 2016-2018, Klara Inc.
- * Copyright (c) 2016-2018, Allan Jude.
- * Copyright (c) 2018-2020, Sebastian Gottschall. All rights reserved.
- * Copyright (c) 2019-2020, Michael Niewöhner. All rights reserved.
- * Copyright (c) 2020, The FreeBSD Foundation. [1]
+ * Copyright (c) 2016-2018, Allan Jude
+ * Copyright (c) 2018-2020, Sebastian Gottschall
+ * Copyright (c) 2019-2020, Michael Niewöhner
+ * Copyright (c) 2020, The FreeBSD Foundation [1]
  *
  * [1] Portions of this software were developed by Allan Jude
  * under sponsorship from the FreeBSD Foundation.

--- a/scripts/dkms.mkconf
+++ b/scripts/dkms.mkconf
@@ -1,4 +1,34 @@
 #!/bin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2013-2019, Brian Behlendorf
+# Copyright (c) 2016, Marcel Huber
+# Copyright (c) 2018, Delphix
+# Copyright (c) 2017, Intel inc.
+# Copyright (c) 2018, Antonio Russo
+# Copyright (c) 2018, Neal Gompa
+# Use is subject to license terms.
+#
 
 PROG=$0
 

--- a/scripts/zfs.sh
+++ b/scripts/zfs.sh
@@ -1,7 +1,38 @@
 #!/bin/sh
 #
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2010-2020, Brian Behlendorf
+# Copyright (c) 2014, 2018, Delphix
+# Copyright (c) 2017, Giuseppe Di Natale
+# Copyright (c) 2020, Ryan Moeller
+# Use is subject to license terms.
+#
+
+#
 # A simple script to load/unload the ZFS module stack.
 #
+
+
 
 BASE_DIR=$(dirname "$0")
 SCRIPT_COMMON=common.sh

--- a/tests/zfs-tests/include/properties.shlib
+++ b/tests/zfs-tests/include/properties.shlib
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright (c) 2012, 2016, Delphix. All rights reserved.
+# Copyright (c) 2012, 2016, Delphix
 #
 
 . $STF_SUITE/include/libtest.shlib

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/zdb_args_neg.ksh
@@ -21,12 +21,9 @@
 #
 
 #
-# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2012, 2017, Delphix
+# Copyright (c) 2008, Sun Microsystems Inc.
 # Use is subject to license terms.
-#
-
-#
-# Copyright (c) 2012, 2017 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -20,13 +20,10 @@
 #
 
 #
-# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2009, Sun Microsystems Inc.
+# Copyright (c) 2013, 2014, Delphix
+# Copyright (c) 2016, Nexenta Systems Inc.
 # Use is subject to license terms.
-#
-
-#
-# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
-# Copyright 2016 Nexenta Systems, Inc. All rights reserved.
 #
 
 # Set the expected properties of zpool

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get_002_pos.ksh
@@ -21,13 +21,11 @@
 #
 
 #
-# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2008 Sun Microsystems Inc.
+# Copyright (c) 2013, 2016 Delphix
 # Use is subject to license terms.
 #
 
-#
-# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
-#
 
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_get/zpool_get.cfg


### PR DESCRIPTION
This PR cleans up some copyright headers for files that where added to the ZSTD on ZFS project after we went over them previously.

It also adds headers for files that had no valid copyright header at all (even though having one is a BSD requirement)