### PR TITLE
ZSTD fixes

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -8787,9 +8787,8 @@ l2arc_apply_transforms(spa_t *spa, arc_buf_hdr_t *hdr, uint64_t asize,
 
 		if (psize >= size) {
 			abd_return_buf(cabd, tmp, asize);
-			abd_free(cabd);
 			HDR_SET_COMPRESS(hdr, ZIO_COMPRESS_OFF);
-			to_write = abd_alloc_for_io(asize, ismd);
+			to_write = cabd;
 			abd_copy(to_write, hdr->b_l1hdr.b_pabd, size);
 			if (size != asize)
 				abd_zero_off(to_write, size, asize - size);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -107,7 +107,7 @@ tests = ['zdb_002_pos', 'zdb_003_pos', 'zdb_004_pos', 'zdb_005_pos',
     'zdb_006_pos', 'zdb_args_neg', 'zdb_args_pos',
     'zdb_block_size_histogram', 'zdb_checksum', 'zdb_decompress',
     'zdb_display_block', 'zdb_object_range_neg', 'zdb_object_range_pos',
-    'zdb_objset_id']
+    'zdb_objset_id', 'zdb_decompress_zstd']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zdb']
@@ -216,7 +216,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_016_pos', 'receive-o-x_props_override',
     'zfs_receive_from_encrypted', 'zfs_receive_to_encrypted',
     'zfs_receive_raw', 'zfs_receive_raw_incremental', 'zfs_receive_-e',
-    'zfs_receive_raw_-d']
+    'zfs_receive_raw_-d', 'zfs_receive_from_zstd']
 tags = ['functional', 'cli_root', 'zfs_receive']
 
 [tests/functional/cli_root/zfs_rename]
@@ -253,7 +253,8 @@ tests = ['cache_001_pos', 'cache_002_neg', 'canmount_001_pos',
     'user_property_001_pos', 'user_property_003_neg', 'readonly_001_pos',
     'user_property_004_pos', 'version_001_neg', 'zfs_set_001_neg',
     'zfs_set_002_neg', 'zfs_set_003_neg', 'property_alias_001_pos',
-    'mountpoint_003_pos', 'ro_props_001_pos', 'zfs_set_keylocation']
+    'mountpoint_003_pos', 'ro_props_001_pos', 'zfs_set_keylocation',
+    'zfs_set_feature_activation']
 tags = ['functional', 'cli_root', 'zfs_set']
 
 [tests/functional/cli_root/zfs_share]

--- a/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zdb/Makefile.am
@@ -10,6 +10,7 @@ dist_pkgdata_SCRIPTS = \
 	zdb_block_size_histogram.ksh \
 	zdb_checksum.ksh \
 	zdb_decompress.ksh \
+	zdb_decompress_zstd.ksh \
 	zdb_object_range_neg.ksh \
 	zdb_object_range_pos.ksh \
 	zdb_display_block.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/Makefile.am
@@ -20,6 +20,7 @@ dist_pkgdata_SCRIPTS = \
 	zfs_receive_016_pos.ksh \
 	receive-o-x_props_override.ksh \
 	zfs_receive_from_encrypted.ksh \
+	zfs_receive_from_zstd.ksh \
 	zfs_receive_to_encrypted.ksh \
 	zfs_receive_raw.ksh \
 	zfs_receive_raw_incremental.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_set/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_set/Makefile.am
@@ -28,7 +28,8 @@ dist_pkgdata_SCRIPTS = \
 	zfs_set_001_neg.ksh \
 	zfs_set_002_neg.ksh \
 	zfs_set_003_neg.ksh \
-	zfs_set_keylocation.ksh
+	zfs_set_keylocation.ksh \
+	zfs_set_feature_activation.ksh
 
 dist_pkgdata_DATA = \
 	zfs_set_common.kshlib


### PR DESCRIPTION
I found some more tests that were not hooked up properly

Also avoid freeing asize worth of memory, then immediately allocating it again, just reuse cabd.