### PR TITLE
Update documentation around ZSTD + zfs send -e

### DIFF
--- a/man/man5/zpool-features.5
+++ b/man/man5/zpool-features.5
@@ -979,10 +979,6 @@ This feature becomes \fBactive\fR once a \fBcompress\fR property has been set to
 have ever had their compress property set to \fBzstd\fR are destroyed.
 
 Booting off of \fBzstd\fR-compressed root pools is not yet supported.
-
-Sending a \fBzstd\fR dataset to a non-\fBzstd\fR pool by \fBzfs send -e\fR is
-not possible and will result in an error. Either drop the \fB-e\fR option or
-enable \fBzstd\fR on the receiver pool.
 .RE
 
 .SH "SEE ALSO"


### PR DESCRIPTION
We now only send ZSTD compressed embedded blockpointers if the
ZSTD send-stream flag is already active (from setting -c)

Sponsored-by: The FreeBSD Foundation
Signed-off-by: Allan Jude <allanjude@freebsd.org>